### PR TITLE
Update EasyNetQ to 3.1.0

### DIFF
--- a/EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer/EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer.csproj
+++ b/EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer/EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="2.2.0" />
-    <PackageReference Include="EasyNetQ.MetaData" Version="1.0.0" />
+    <PackageReference Include="EasyNetQ" Version="3.1.0" />
+    <PackageReference Include="EasyNetQ.MetaData" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer/Program.cs
+++ b/EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer/Program.cs
@@ -1,18 +1,16 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer {
-    using System;
-    using System.Threading;
-    using EasyNetQ.ExtensibleContentEncoding;
-    using EasyNetQ.ExtensibleContentEncoding.TestBench.Messages;
-    using EasyNetQ.MetaData;
+﻿using System;
+using System.Threading;
+using EasyNetQ.ExtensibleContentEncoding.TestBench.Messages;
+using EasyNetQ.Interception;
+using EasyNetQ.Logging;
+using EasyNetQ.MetaData;
 
-    using global::EasyNetQ;
-    using global::EasyNetQ.Interception;
-    using global::EasyNetQ.Loggers;
-
+namespace EasyNetQ.ExtensibleContentEncoding.TestBench.Consumer {
     class Program {
         static void Main() {
+            LogProvider.SetCurrentLogProvider(ConsoleLogProvider.Instance);
+
             var bus = RabbitHutch.CreateBus("host=localhost;username=guest;password=guest", registrar => {
-                registrar.Register<IEasyNetQLogger>(_ => new ConsoleLogger());
                 registrar.EnableMessageMetaDataBinding();
 
                 registrar.EnableInterception(interception => {

--- a/EasyNetQ.ExtensibleContentEncoding.TestBench.Messages/EasyNetQ.ExtensibleContentEncoding.TestBench.Messages.csproj
+++ b/EasyNetQ.ExtensibleContentEncoding.TestBench.Messages/EasyNetQ.ExtensibleContentEncoding.TestBench.Messages.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ.MetaData.Abstractions" Version="1.0.0" />
+    <PackageReference Include="EasyNetQ.MetaData.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/EasyNetQ.ExtensibleContentEncoding.TestBench.Messages/TestMessage.cs
+++ b/EasyNetQ.ExtensibleContentEncoding.TestBench.Messages/TestMessage.cs
@@ -1,12 +1,12 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.TestBench.Messages {
-    using System;
-    using System.Runtime.Serialization;
-    using EasyNetQ.MetaData.Abstractions;
+﻿using System;
+using System.Runtime.Serialization;
+using EasyNetQ.MetaData.Abstractions;
 
+namespace EasyNetQ.ExtensibleContentEncoding.TestBench.Messages {
     public class TestMessage {
-        public String Content { get; set; }
+        public string Content { get; set; }
 
         [MessageProperty(Property.ContentEncoding), IgnoreDataMember]
-        public String ContentEncoding { get; set; }
+        public string ContentEncoding { get; set; }
     }
 }

--- a/EasyNetQ.ExtensibleContentEncoding.TestBench.Producer/EasyNetQ.ExtensibleContentEncoding.TestBench.Producer.csproj
+++ b/EasyNetQ.ExtensibleContentEncoding.TestBench.Producer/EasyNetQ.ExtensibleContentEncoding.TestBench.Producer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="2.2.0" />
-    <PackageReference Include="EasyNetQ.MetaData" Version="1.0.0" />
+    <PackageReference Include="EasyNetQ" Version="3.1.0" />
+    <PackageReference Include="EasyNetQ.MetaData" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyNetQ.ExtensibleContentEncoding.TestBench.Producer/Program.cs
+++ b/EasyNetQ.ExtensibleContentEncoding.TestBench.Producer/Program.cs
@@ -1,17 +1,15 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.TestBench.Producer {
-    using System;
-    using EasyNetQ.ExtensibleContentEncoding;
-    using EasyNetQ.ExtensibleContentEncoding.TestBench.Messages;
-    using EasyNetQ.MetaData;
+﻿using System;
+using EasyNetQ.ExtensibleContentEncoding.TestBench.Messages;
+using EasyNetQ.Interception;
+using EasyNetQ.Logging;
+using EasyNetQ.MetaData;
 
-    using global::EasyNetQ;
-    using global::EasyNetQ.Interception;
-    using global::EasyNetQ.Loggers;
-
+namespace EasyNetQ.ExtensibleContentEncoding.TestBench.Producer {
     class Program {
         static void Main() {
+            LogProvider.SetCurrentLogProvider(ConsoleLogProvider.Instance);
+
             var bus = RabbitHutch.CreateBus("host=localhost;username=guest;password=guest", registrar => {
-                registrar.Register<IEasyNetQLogger>(_ => new ConsoleLogger());
                 registrar.EnableMessageMetaDataBinding();
 
                 registrar.EnableInterception(interception => {

--- a/EasyNetQ.ExtensibleContentEncoding.Tests/AdvancedDecodingInterceptorTests.cs
+++ b/EasyNetQ.ExtensibleContentEncoding.Tests/AdvancedDecodingInterceptorTests.cs
@@ -1,13 +1,12 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Tests {
-    using System;
-    using System.IO;
-    using System.Security.Cryptography;
-    using System.Text;
-    using EasyNetQ.ExtensibleContentEncoding.Codecs;
-    using Xunit;
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using EasyNetQ.ExtensibleContentEncoding.Codecs;
+using EasyNetQ.Interception;
+using Xunit;
 
-    using global::EasyNetQ.Interception;
-
+namespace EasyNetQ.ExtensibleContentEncoding.Tests {
     public class AdvancedDecodingInterceptorTests {
         [Fact]
         public void CodecIdentity() {
@@ -38,7 +37,7 @@
             var subject = new ExtensibleContentEncodingInterceptor();
             var encoded = subject.OnProduce(input);
 
-            Assert.Equal(new Byte[] { 31, 139, 8, 0, 0, 0, 0, 0, 0, 11, 43, 73, 45, 46, 1, 0, 12, 126, 127, 216, 4, 0, 0, 0 }, encoded.Body);
+            Assert.Equal(new byte[] { 31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 43, 73, 45, 46, 1, 0, 12, 126, 127, 216, 4, 0, 0, 0 }, encoded.Body);
 
             var decoded = subject.OnConsume(encoded);
 
@@ -56,7 +55,7 @@
             var subject = new ExtensibleContentEncodingInterceptor();
             var encoded = subject.OnProduce(input);
 
-            Assert.Equal(new Byte[] { 43, 73, 45, 46, 1, 0 }, encoded.Body);
+            Assert.Equal(new byte[] { 43, 73, 45, 46, 1, 0 }, encoded.Body);
 
             var decoded = subject.OnConsume(encoded);
 
@@ -74,7 +73,7 @@
             var subject = new ExtensibleContentEncodingInterceptor();
             var encoded = subject.OnProduce(input);
 
-            Assert.Equal(new Byte[] { 139, 1, 128, 116, 101, 115, 116, 3 }, encoded.Body);
+            Assert.Equal(new byte[] { 139, 1, 128, 116, 101, 115, 116, 3 }, encoded.Body);
 
             var decoded = subject.OnConsume(encoded);
 
@@ -92,7 +91,7 @@
             var subject = new ExtensibleContentEncodingInterceptor();
             var encoded = subject.OnProduce(input);
 
-            Assert.Equal(new Byte[] { 147, 239, 230, 96, 0, 3, 110, 109, 79, 93, 61, 70, 6, 158, 186, 250, 27, 44, 64, 46, 0 }, encoded.Body);
+            Assert.Equal(new byte[] { 147, 239, 230, 96, 0, 3, 102, 109, 79, 93, 61, 70, 6, 158, 186, 250, 27, 44, 64, 46, 0 }, encoded.Body);
 
             var decoded = subject.OnConsume(encoded);
 

--- a/EasyNetQ.ExtensibleContentEncoding.Tests/EasyNetQ.ExtensibleContentEncoding.Tests.csproj
+++ b/EasyNetQ.ExtensibleContentEncoding.Tests/EasyNetQ.ExtensibleContentEncoding.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="EasyNetQ" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyNetQ.ExtensibleContentEncoding/Codecs/BrotliCodec.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/Codecs/BrotliCodec.cs
@@ -1,9 +1,9 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
-    using System;
-    using System.IO;
-    using System.IO.Compression;
-    using BrotliSharpLib;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using BrotliSharpLib;
 
+namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
     class BrotliCodec : ICodec {
         public Stream AddEncodingStage(Stream baseStream) {
             if (baseStream == null)

--- a/EasyNetQ.ExtensibleContentEncoding/Codecs/DeflateCodec.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/Codecs/DeflateCodec.cs
@@ -1,8 +1,8 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
-    using System;
-    using System.IO;
-    using System.IO.Compression;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
 
+namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
     class DeflateCodec : ICodec {
         public Stream AddEncodingStage(Stream baseStream) {
             if (baseStream == null)

--- a/EasyNetQ.ExtensibleContentEncoding/Codecs/GZipCodec.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/Codecs/GZipCodec.cs
@@ -1,8 +1,8 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
-    using System;
-    using System.IO;
-    using System.IO.Compression;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
 
+namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
     class GZipCodec : ICodec {
         public Stream AddEncodingStage(Stream baseStream) {
             if (baseStream == null)

--- a/EasyNetQ.ExtensibleContentEncoding/Codecs/ICodec.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/Codecs/ICodec.cs
@@ -1,6 +1,6 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
-    using System.IO;
+﻿using System.IO;
 
+namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
     /// <summary>
     /// Defines the interface for an object which can encode and decode message payloads, and can be assembled
     /// into a pipeline.

--- a/EasyNetQ.ExtensibleContentEncoding/Codecs/IdentityCodec.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/Codecs/IdentityCodec.cs
@@ -1,7 +1,7 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
-    using System;
-    using System.IO;
+﻿using System;
+using System.IO;
 
+namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
     class IdentityCodec : ICodec {
         public Stream AddEncodingStage(Stream baseStream) {
             if (baseStream == null)

--- a/EasyNetQ.ExtensibleContentEncoding/Codecs/IdentityStream.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/Codecs/IdentityStream.cs
@@ -1,7 +1,7 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
-    using System;
-    using System.IO;
+﻿using System;
+using System.IO;
 
+namespace EasyNetQ.ExtensibleContentEncoding.Codecs {
     class IdentityStream : Stream {
         readonly Stream _inner;
 
@@ -9,12 +9,12 @@
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         }
 
-        public override Boolean CanRead => _inner.CanRead;
-        public override Boolean CanSeek => _inner.CanSeek;
-        public override Boolean CanWrite => _inner.CanWrite;
-        public override Int64 Length => _inner.Length;
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => _inner.CanSeek;
+        public override bool CanWrite => _inner.CanWrite;
+        public override long Length => _inner.Length;
 
-        public override Int64 Position {
+        public override long Position {
             get => _inner.Position;
             set => _inner.Position = value;
         }
@@ -23,23 +23,23 @@
             _inner.Flush();
         }
 
-        public override Int32 Read(Byte[] buffer, Int32 offset, Int32 count) {
+        public override int Read(byte[] buffer, int offset, int count) {
             return _inner.Read(buffer, offset, count);
         }
 
-        public override Int64 Seek(Int64 offset, SeekOrigin origin) {
+        public override long Seek(long offset, SeekOrigin origin) {
             return _inner.Seek(offset, origin);
         }
 
-        public override void SetLength(Int64 value) {
+        public override void SetLength(long value) {
             _inner.SetLength(value);
         }
 
-        public override void Write(Byte[] buffer, Int32 offset, Int32 count) {
+        public override void Write(byte[] buffer, int offset, int count) {
             _inner.Write(buffer, offset, count);
         }
 
-        protected override void Dispose(Boolean disposing) {
+        protected override void Dispose(bool disposing) {
             base.Dispose(disposing);
         }
     }

--- a/EasyNetQ.ExtensibleContentEncoding/DefaultCodecFactory.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/DefaultCodecFactory.cs
@@ -1,22 +1,22 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding {
-    using System;
-    using System.Collections.Generic;
-    using EasyNetQ.ExtensibleContentEncoding.Codecs;
+﻿using System;
+using System.Collections.Generic;
+using EasyNetQ.ExtensibleContentEncoding.Codecs;
 
+namespace EasyNetQ.ExtensibleContentEncoding {
     class DefaultCodecFactory : ICodecMap {
-        readonly IDictionary<String, ICodec> _codecs;
+        readonly IDictionary<string, ICodec> _codecs;
 
         public DefaultCodecFactory() {
-            _codecs = new Dictionary<String, ICodec> {
+            _codecs = new Dictionary<string, ICodec> {
                 { "identity", new IdentityCodec() },
                 { "gzip",     new GZipCodec() },
                 { "x-gzip",   new GZipCodec() },
                 { "deflate",  new DeflateCodec() },
-                { "br",       new BrotliCodec() },
+                { "br",       new BrotliCodec() }
             };
         }
 
-        public ICodec this[String key] {
+        public ICodec this[string key] {
             get {
                 try {
                     return _codecs[key];

--- a/EasyNetQ.ExtensibleContentEncoding/EasyNetQ.ExtensibleContentEncoding.csproj
+++ b/EasyNetQ.ExtensibleContentEncoding/EasyNetQ.ExtensibleContentEncoding.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BrotliSharpLib" Version="0.2.1" />
-    <PackageReference Include="EasyNetQ" Version="2.2.0" />
+    <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
+    <PackageReference Include="EasyNetQ" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/EasyNetQ.ExtensibleContentEncoding/ExtensibleContentEncodingInterceptor.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/ExtensibleContentEncodingInterceptor.cs
@@ -1,14 +1,13 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using EasyNetQ.ExtensibleContentEncoding.Codecs;
+using EasyNetQ.Interception;
+
+namespace EasyNetQ.ExtensibleContentEncoding
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using EasyNetQ.ExtensibleContentEncoding.Codecs;
-
-    using global::EasyNetQ.Interception;
-
     /// <summary>
     /// Defines an implementation of <see cref="IProduceConsumeInterceptor"/> which encodes and decodes message content
     /// based on the value of the 'content_encoding' attribute.
@@ -60,7 +59,8 @@
             }
         }
 
-        IEnumerable<ICodec> GetCodecSequence(MessageProperties properties) {
+        IEnumerable<ICodec> GetCodecSequence(MessageProperties properties)
+        {
             if (properties.ContentEncodingPresent) {
                 try {
                     return Regex.Matches(properties.ContentEncoding, @"(\w+)")
@@ -72,9 +72,8 @@
                     throw new Exception("Unable to parse content_encoding attribute: " + properties.ContentEncoding);
                 }
             }
-            else {
-                return new [] { new IdentityCodec() };
-            }
+
+            return new [] { new IdentityCodec() };
         }
     }
 }

--- a/EasyNetQ.ExtensibleContentEncoding/ICodecMap.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/ICodecMap.cs
@@ -1,7 +1,7 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding {
-    using System;
-    using EasyNetQ.ExtensibleContentEncoding.Codecs;
+﻿using System;
+using EasyNetQ.ExtensibleContentEncoding.Codecs;
 
+namespace EasyNetQ.ExtensibleContentEncoding {
     /// <summary>
     /// Defines mapping between content-encoding header values and <see cref="ICodec"/> objects.
     /// </summary>
@@ -14,6 +14,6 @@
         /// <exception cref="UnknownEncodingException">
         /// Thrown when trying to retrieve an encoding for which there is no <see cref="ICodec"/> associated.
         /// </exception>
-        ICodec this[String key] { get; set; }
+        ICodec this[string key] { get; set; }
     }
 }

--- a/EasyNetQ.ExtensibleContentEncoding/InterceptionExtensions.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/InterceptionExtensions.cs
@@ -1,7 +1,7 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding {
-    using System;
-    using global::EasyNetQ.Interception;
+﻿using System;
+using EasyNetQ.Interception;
 
+namespace EasyNetQ.ExtensibleContentEncoding {
     /// <summary>
     /// Defines extension methods for the <see cref="IInterceptorRegistrator"/> interface.
     /// </summary>

--- a/EasyNetQ.ExtensibleContentEncoding/UnknownEncodingException.cs
+++ b/EasyNetQ.ExtensibleContentEncoding/UnknownEncodingException.cs
@@ -1,6 +1,6 @@
-﻿namespace EasyNetQ.ExtensibleContentEncoding {
-    using System;
+﻿using System;
 
+namespace EasyNetQ.ExtensibleContentEncoding {
     /// <summary>
     /// Represents errors that occur when trying to encode or decode a message payload with an encoding that is not
     /// recognized or supported.
@@ -10,7 +10,7 @@
         /// Initializes a new instance of the <see cref="UnknownEncodingException"/> class.
         /// </summary>
         /// <param name="encoding">The encoding which is unknown or unsupported.</param>
-        public UnknownEncodingException(String encoding)
+        public UnknownEncodingException(string encoding)
             : base("Unknown encoding: " + encoding) {
         }
     }


### PR DESCRIPTION
I have upgraded EasyNetQ to version 3.1.0. I would have loved to use the recent 3.4.5, but this is the only version that seems works with [EasyNetQ.MetaData](https://github.com/Matthew-Davey/EasyNetQ.MetaData) 2.0.0.

All other libraries were upgraded as well, so Brotli is now on 0.3.3, for example.